### PR TITLE
Fix "0" value handling for various options

### DIFF
--- a/.changeset/brave-otters-cross.md
+++ b/.changeset/brave-otters-cross.md
@@ -1,0 +1,5 @@
+---
+"@imgproxy/imgproxy-js-core": major
+---
+
+Add a rule that unsharpMasking.weight should be greater than 0

--- a/.changeset/clever-poems-bathe.md
+++ b/.changeset/clever-poems-bathe.md
@@ -1,0 +1,5 @@
+---
+"@imgproxy/imgproxy-js-core": major
+---
+
+Fix handling of 0 values for `adjust` option. Previously `contrast:0` was incorrectly coded as `contrast:` with default value 1

--- a/.changeset/large-walls-think.md
+++ b/.changeset/large-walls-think.md
@@ -1,0 +1,5 @@
+---
+"@imgproxy/imgproxy-js-core": patch
+---
+
+Make sure that 0 is treated the same for short and long option names

--- a/.changeset/yellow-fireants-obey.md
+++ b/.changeset/yellow-fireants-obey.md
@@ -1,0 +1,5 @@
+---
+"@imgproxy/imgproxy-js-core": patch
+---
+
+Fix handling of 0 values for `autoquality` option

--- a/src/options/adjust.ts
+++ b/src/options/adjust.ts
@@ -11,14 +11,14 @@ const build = (options: AdjustOptionsPartial): string => {
   const adjustOpts = getOpt(options);
 
   guardIsUndef(adjustOpts, "adjust");
-  if (adjustOpts.brightness)
+  if (adjustOpts.brightness !== undefined)
     guardIsNotNum(adjustOpts.brightness, "adjust.brightness", {
       addParam: { min: -255, max: 255 },
     });
 
-  const brightness = adjustOpts.brightness || "";
-  const contrast = adjustOpts.contrast || "";
-  const saturation = adjustOpts.saturation || "";
+  const brightness = adjustOpts.brightness ?? "";
+  const contrast = adjustOpts.contrast ?? "";
+  const saturation = adjustOpts.saturation ?? "";
 
   return `a:${brightness}:${contrast}:${saturation}`;
 };

--- a/src/options/autoquality.ts
+++ b/src/options/autoquality.ts
@@ -24,19 +24,19 @@ const build = (options: AutoqualityOptionsPartial): string => {
   const { method, target, min_quality, max_quality, allowed_error } =
     autoqualityOpts;
   if (method) guardIsValidVal(currentMethods, method, "autoquality.method");
-  if (target)
+  if (target !== undefined)
     guardIsNotNum(target, "autoquality.target", {
       addParam: { min: 0 },
     });
-  if (min_quality)
+  if (min_quality !== undefined)
     guardIsNotNum(min_quality, "autoquality.min_quality", {
       addParam: { min: 0, max: 100 },
     });
-  if (max_quality)
+  if (max_quality !== undefined)
     guardIsNotNum(max_quality, "autoquality.max_quality", {
       addParam: { min: 0, max: 100 },
     });
-  if (allowed_error) {
+  if (allowed_error !== undefined) {
     if (method !== "dssim" && method !== "ml") {
       throw new Error(
         "autoquality.allowed_error is applicable only to dssim and ml methods"
@@ -47,11 +47,11 @@ const build = (options: AutoqualityOptionsPartial): string => {
     });
   }
 
-  const m = method || "";
-  const t = target || "";
-  const minQuality = min_quality || "";
-  const maxQuality = max_quality || "";
-  const ae = allowed_error || "";
+  const m = method ?? "";
+  const t = target ?? "";
+  const minQuality = min_quality ?? "";
+  const maxQuality = max_quality ?? "";
+  const ae = allowed_error ?? "";
 
   return `aq:${m}:${t}:${minQuality}:${maxQuality}:${ae}`.replace(/:+$/, "");
 };

--- a/src/options/backgroundAlpha.ts
+++ b/src/options/backgroundAlpha.ts
@@ -6,7 +6,7 @@ import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (
   options: BackgroundAlphaOptionsPartial
-): BackgroundAlpha | undefined => options.background_alpha || options.bga;
+): BackgroundAlpha | undefined => options.background_alpha ?? options.bga;
 
 const test = (options: BackgroundAlphaOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/blur.ts
+++ b/src/options/blur.ts
@@ -2,7 +2,7 @@ import type { Blur, BlurOptionsPartial } from "../types/blur";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: BlurOptionsPartial): Blur | undefined =>
-  options.blur || options.bl;
+  options.blur ?? options.bl;
 
 const test = (options: BlurOptionsPartial): boolean => Boolean(getOpt(options));
 

--- a/src/options/brightness.ts
+++ b/src/options/brightness.ts
@@ -2,7 +2,7 @@ import type { Brightness, BrightnessOptionsPartial } from "../types/brightness";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: BrightnessOptionsPartial): Brightness | undefined =>
-  options.brightness || options.br;
+  options.brightness ?? options.br;
 
 const test = (options: BrightnessOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/contrast.ts
+++ b/src/options/contrast.ts
@@ -2,7 +2,7 @@ import type { Contrast, ContrastOptionsPartial } from "../types/contrast";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: ContrastOptionsPartial): Contrast | undefined =>
-  options.contrast || options.co;
+  options.contrast ?? options.co;
 
 const test = (options: ContrastOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/height.ts
+++ b/src/options/height.ts
@@ -2,7 +2,7 @@ import type { Height, HeightOptionsPartial } from "../types/height";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: HeightOptionsPartial): Height | undefined =>
-  options.height || options.h;
+  options.height ?? options.h;
 
 const test = (options: HeightOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/maxBytes.ts
+++ b/src/options/maxBytes.ts
@@ -2,7 +2,7 @@ import type { MaxBytes, MaxBytesOptionsPartial } from "../types/maxBytes";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: MaxBytesOptionsPartial): MaxBytes | undefined =>
-  options.max_bytes || options.mb;
+  options.max_bytes ?? options.mb;
 
 const test = (options: MaxBytesOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/minHeight.ts
+++ b/src/options/minHeight.ts
@@ -2,7 +2,7 @@ import type { MinHeight, MinHeightOptionsPartial } from "../types/minHeight";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: MinHeightOptionsPartial): MinHeight | undefined =>
-  options.min_height || options.mh;
+  options.min_height ?? options.mh;
 
 const test = (options: MinHeightOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/minWidth.ts
+++ b/src/options/minWidth.ts
@@ -2,7 +2,7 @@ import type { MinWidth, MinWidthOptionsPartial } from "../types/minWidth";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: MinWidthOptionsPartial): MinWidth | undefined =>
-  options.min_width || options.mw;
+  options.min_width ?? options.mw;
 
 const test = (options: MinWidthOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/pixelate.ts
+++ b/src/options/pixelate.ts
@@ -2,7 +2,7 @@ import type { Pixelate, PixelateOptionsPartial } from "../types/pixelate";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: PixelateOptionsPartial): Pixelate | undefined =>
-  options.pixelate || options.pix;
+  options.pixelate ?? options.pix;
 
 const test = (options: PixelateOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/quality.ts
+++ b/src/options/quality.ts
@@ -2,7 +2,7 @@ import type { Quality, QualityOptionsPartial } from "../types/quality";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: QualityOptionsPartial): Quality | undefined =>
-  options.quality || options.q;
+  options.quality ?? options.q;
 
 const test = (options: QualityOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/rotate.ts
+++ b/src/options/rotate.ts
@@ -9,7 +9,7 @@ const correctAngles = {
 };
 
 const getOpt = (options: RotateOptionsPartial): Rotate | undefined =>
-  options.rotate || options.rot;
+  options.rotate ?? options.rot;
 
 const test = (options: RotateOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/saturation.ts
+++ b/src/options/saturation.ts
@@ -2,7 +2,7 @@ import type { Saturation, SaturationOptionsPartial } from "../types/saturation";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: SaturationOptionsPartial): Saturation | undefined =>
-  options.saturation || options.sa;
+  options.saturation ?? options.sa;
 
 const test = (options: SaturationOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/sharpen.ts
+++ b/src/options/sharpen.ts
@@ -2,7 +2,7 @@ import type { Sharpen, SharpenOptionsPartial } from "../types/sharpen";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: SharpenOptionsPartial): Sharpen | undefined =>
-  options.sharpen || options.sh;
+  options.sharpen ?? options.sh;
 
 const test = (options: SharpenOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/unsharpMasking.ts
+++ b/src/options/unsharpMasking.ts
@@ -23,11 +23,11 @@ const build = (options: UnsharpMaskingOptionsPartial): string => {
   guardIsUndef(unsharpMaskingOpts, "unsharp_masking");
   const { mode, weight, divider } = unsharpMaskingOpts;
   if (mode) guardIsValidVal(correctMode, mode, "unsharp_masking.mode");
-  if (weight)
+  if (weight !== undefined)
     guardIsNotNum(weight, "unsharp_masking.weight", {
       addParam: { min: 0, minEqual: true },
     });
-  if (divider)
+  if (divider !== undefined)
     guardIsNotNum(divider, "unsharp_masking.divider", {
       addParam: { min: 0, minEqual: true },
     });

--- a/src/options/watermarkShadow.ts
+++ b/src/options/watermarkShadow.ts
@@ -6,7 +6,7 @@ import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (
   options: WatermarkShadowOptionsPartial
-): WatermarkShadow | undefined => options.watermark_shadow || options.wmsh;
+): WatermarkShadow | undefined => options.watermark_shadow ?? options.wmsh;
 
 const test = (options: WatermarkShadowOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/src/options/width.ts
+++ b/src/options/width.ts
@@ -2,7 +2,7 @@ import type { Width, WidthOptionsPartial } from "../types/width";
 import { guardIsUndef, guardIsNotNum } from "../utils";
 
 const getOpt = (options: WidthOptionsPartial): Width | undefined =>
-  options.width || options.w;
+  options.width ?? options.w;
 
 const test = (options: WidthOptionsPartial): boolean =>
   Boolean(getOpt(options));

--- a/tests/optionsBasic/adjust.test.ts
+++ b/tests/optionsBasic/adjust.test.ts
@@ -73,5 +73,11 @@ describe("adjust", () => {
     it("should return value of saturation if brightness and contrast are undefined", () => {
       expect(build({ adjust: { saturation: 1.2 } })).toEqual("a:::1.2");
     });
+
+    it("should correctly handle 0 for `brightness`, `contrast`, and `saturation`", () => {
+      expect(
+        build({ adjust: { brightness: 0, contrast: 0, saturation: 0 } })
+      ).toEqual("a:0:0:0");
+    });
   });
 });

--- a/tests/optionsBasic/autoquality.test.ts
+++ b/tests/optionsBasic/autoquality.test.ts
@@ -141,5 +141,19 @@ describe("autoquality", () => {
         })
       ).toEqual("aq:ml::::0.007");
     });
+
+    it("should correctly handle 0 values for numeric properties", () => {
+      expect(
+        build({
+          aq: {
+            method: "dssim",
+            min_quality: 0,
+            max_quality: 0,
+            allowed_error: 0,
+            target: 0,
+          },
+        })
+      ).toEqual("aq:dssim:0:0:0:0");
+    });
   });
 });

--- a/tests/optionsBasic/backgroundAlpha.test.ts
+++ b/tests/optionsBasic/backgroundAlpha.test.ts
@@ -46,5 +46,10 @@ describe("backgroundAlpha", () => {
     it("should return value of background alpha if bga option is defined", () => {
       expect(build({ bga: 0.5 })).toEqual("background_alpha:0.5");
     });
+
+    it("should return value of background alpha if bga option is 0", () => {
+      expect(build({ bga: 0 })).toEqual("background_alpha:0");
+      expect(build({ background_alpha: 0 })).toEqual("background_alpha:0");
+    });
   });
 });

--- a/tests/optionsBasic/blur.test.ts
+++ b/tests/optionsBasic/blur.test.ts
@@ -38,5 +38,10 @@ describe("blur", () => {
     it("should return value of blur if bl option is defined", () => {
       expect(build({ bl: 15 })).toEqual("bl:15");
     });
+
+    it("should return value of blur if bl option is 0", () => {
+      expect(build({ bl: 0 })).toEqual("bl:0");
+      expect(build({ blur: 0 })).toEqual("bl:0");
+    });
   });
 });

--- a/tests/optionsBasic/brightness.test.ts
+++ b/tests/optionsBasic/brightness.test.ts
@@ -43,6 +43,11 @@ describe("brightness", () => {
       expect(build({ brightness: 255 })).toEqual("br:255");
     });
 
+    it("should correctly handle 0 value", () => {
+      expect(build({ brightness: 0 })).toEqual("br:0");
+      expect(build({ br: 0 })).toEqual("br:0");
+    });
+
     it("should return value of brightness if br option is defined", () => {
       expect(build({ br: -150 })).toEqual("br:-150");
     });

--- a/tests/optionsBasic/contrast.test.ts
+++ b/tests/optionsBasic/contrast.test.ts
@@ -37,5 +37,10 @@ describe("contrast", () => {
     it("should return co:150 if contrast option is 150", () => {
       expect(build({ contrast: 150 })).toEqual("co:150");
     });
+
+    it("should correctly handle 0 contrast", () => {
+      expect(build({ contrast: 0 })).toEqual("co:0");
+      expect(build({ co: 0 })).toEqual("co:0");
+    });
   });
 });

--- a/tests/optionsBasic/dpi.test.ts
+++ b/tests/optionsBasic/dpi.test.ts
@@ -25,5 +25,9 @@ describe("dpi", () => {
     it("should return dpi:150 if dpi option is 150", () => {
       expect(build({ dpi: 150 })).toEqual("dpi:150");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ dpi: 0 })).toEqual("dpi:0");
+    });
   });
 });

--- a/tests/optionsBasic/dpr.test.ts
+++ b/tests/optionsBasic/dpr.test.ts
@@ -31,5 +31,9 @@ describe("dpr", () => {
     it("should return value of dpr if dpr option is defined", () => {
       expect(build({ dpr: 100 })).toEqual("dpr:100");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ dpr: 0 })).toEqual("dpr:0");
+    });
   });
 });

--- a/tests/optionsBasic/gradient.test.ts
+++ b/tests/optionsBasic/gradient.test.ts
@@ -168,5 +168,16 @@ describe("gradient", () => {
         })
       ).toEqual("gr:0.15::::0.85");
     });
+
+    it("should correctly handle 0 opacity", () => {
+      expect(
+        build({
+          gradient: {
+            opacity: 0,
+            stop: 0.85,
+          },
+        })
+      ).toEqual("gr:0::::0.85");
+    });
   });
 });

--- a/tests/optionsBasic/height.test.ts
+++ b/tests/optionsBasic/height.test.ts
@@ -41,5 +41,10 @@ describe("height", () => {
     it("should return h:250 if w option is 250", () => {
       expect(build({ h: 250 })).toEqual("h:250");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ h: 0 })).toEqual("h:0");
+      expect(build({ height: 0 })).toEqual("h:0");
+    });
   });
 });

--- a/tests/optionsBasic/maxAnimationFrameResolution.test.ts
+++ b/tests/optionsBasic/maxAnimationFrameResolution.test.ts
@@ -47,5 +47,10 @@ describe("maxAnimationFrameResolution", () => {
     it("should return mafr:84 if max_animation_frame_resolution option is 84", () => {
       expect(build({ max_animation_frame_resolution: 84 })).toEqual("mafr:84");
     });
+
+    it("should work with 0", () => {
+      expect(build({ max_animation_frame_resolution: 0 })).toEqual("mafr:0");
+      expect(build({ mafr: 0 })).toEqual("mafr:0");
+    });
   });
 });

--- a/tests/optionsBasic/maxBytes.test.ts
+++ b/tests/optionsBasic/maxBytes.test.ts
@@ -41,5 +41,10 @@ describe("maxBytes", () => {
     it("should return mb:500 if mb option is 500", () => {
       expect(build({ mb: 500 })).toEqual("mb:500");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ mb: 0 })).toEqual("mb:0");
+      expect(build({ max_bytes: 0 })).toEqual("mb:0");
+    });
   });
 });

--- a/tests/optionsBasic/minHeight.test.ts
+++ b/tests/optionsBasic/minHeight.test.ts
@@ -41,5 +41,10 @@ describe("min_height", () => {
     it("should return mh:333 if mh option is 333", () => {
       expect(build({ mh: 333 })).toEqual("mh:333");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ mh: 0 })).toEqual("mh:0");
+      expect(build({ min_height: 0 })).toEqual("mh:0");
+    });
   });
 });

--- a/tests/optionsBasic/minWidth.test.ts
+++ b/tests/optionsBasic/minWidth.test.ts
@@ -41,5 +41,10 @@ describe("min_width", () => {
     it("should return mw:500 if mw option is 500", () => {
       expect(build({ mw: 500 })).toEqual("mw:500");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ mw: 0 })).toEqual("mw:0");
+      expect(build({ min_width: 0 })).toEqual("mw:0");
+    });
   });
 });

--- a/tests/optionsBasic/pixelate.test.ts
+++ b/tests/optionsBasic/pixelate.test.ts
@@ -41,5 +41,10 @@ describe("pixelate", () => {
     it("should return pix:7 if pix option is 7", () => {
       expect(build({ pix: 7 })).toEqual("pix:7");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ pix: 0 })).toEqual("pix:0");
+      expect(build({ pixelate: 0 })).toEqual("pix:0");
+    });
   });
 });

--- a/tests/optionsBasic/quality.test.ts
+++ b/tests/optionsBasic/quality.test.ts
@@ -43,5 +43,10 @@ describe("quality", () => {
     it("should return q:77 if quality option is 77", () => {
       expect(build({ quality: 77 })).toEqual("q:77");
     });
+
+    it("should correctly handle 0", () => {
+      expect(build({ quality: 0 })).toEqual("q:0");
+      expect(build({ q: 0 })).toEqual("q:0");
+    });
   });
 });

--- a/tests/optionsBasic/rotate.test.ts
+++ b/tests/optionsBasic/rotate.test.ts
@@ -42,5 +42,10 @@ describe("rotate", () => {
     it("should return rot:270 if rot option is 270", () => {
       expect(build({ rot: 270 })).toEqual("rot:270");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ rot: 0 })).toEqual("rot:0");
+      expect(build({ rotate: 0 })).toEqual("rot:0");
+    });
   });
 });

--- a/tests/optionsBasic/saturation.test.ts
+++ b/tests/optionsBasic/saturation.test.ts
@@ -37,5 +37,10 @@ describe("saturation", () => {
     it("should return sa:30 if saturation option is 30", () => {
       expect(build({ saturation: 30 })).toEqual("sa:30");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ saturation: 0 })).toEqual("sa:0");
+      expect(build({ sa: 0 })).toEqual("sa:0");
+    });
   });
 });

--- a/tests/optionsBasic/sharpen.test.ts
+++ b/tests/optionsBasic/sharpen.test.ts
@@ -37,5 +37,10 @@ describe("sharpen", () => {
     it("should return sh:0.5 if sharpen option is 0.5", () => {
       expect(build({ sharpen: 0.5 })).toEqual("sh:0.5");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ sharpen: 0 })).toEqual("sh:0");
+      expect(build({ sh: 0 })).toEqual("sh:0");
+    });
   });
 });

--- a/tests/optionsBasic/unsharpMasking.test.ts
+++ b/tests/optionsBasic/unsharpMasking.test.ts
@@ -45,12 +45,21 @@ describe("unsharpMasking", () => {
       expect(() => build({ unsharp_masking: { divider: -1 } })).toThrow(
         "unsharp_masking.divider value can't be less or equal then 0"
       );
+      expect(() => build({ unsharp_masking: { divider: 0 } })).toThrow(
+        "unsharp_masking.divider value can't be less or equal then 0"
+      );
     });
 
     it("should throw an error if unsharp_masking.divider is not a number", () => {
       // @ts-expect-error: Let's ignore an error (check for users with vanilla js).
       expect(() => build({ unsharp_masking: { divider: "test" } })).toThrow(
         "unsharp_masking.divider is not a number"
+      );
+    });
+
+    it("should throw an error if unsharp_masking.weight is not greater than zero", () => {
+      expect(() => build({ unsharp_masking: { weight: 0 } })).toThrow(
+        "unsharp_masking.weight value can't be less or equal then 0"
       );
     });
 

--- a/tests/optionsBasic/watermarkShadow.test.ts
+++ b/tests/optionsBasic/watermarkShadow.test.ts
@@ -41,5 +41,10 @@ describe("watermarkShadow", () => {
     it("should return wmsh:36 if wmsh option is 36", () => {
       expect(build({ wmsh: 36 })).toEqual("wmsh:36");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ wmsh: 0 })).toEqual("wmsh:0");
+      expect(build({ watermark_shadow: 0 })).toEqual("wmsh:0");
+    });
   });
 });

--- a/tests/optionsBasic/width.test.ts
+++ b/tests/optionsBasic/width.test.ts
@@ -41,5 +41,10 @@ describe("width", () => {
     it("should return w:500 if w option is 500", () => {
       expect(build({ w: 500 })).toEqual("w:500");
     });
+
+    it("should correctly handle 0 value", () => {
+      expect(build({ w: 0 })).toEqual("w:0");
+      expect(build({ width: 0 })).toEqual("w:0");
+    });
   });
 });


### PR DESCRIPTION
In continuation for #21 I went through options and fixed a bunch of discrepancies with 0 handling:
- Fix `contrast` in `adjust` option. Contrast 0  was coded as "co:" so that it incorrectly took 1 as default
- Make sure all 0es in `autoquality` option are passed as numbers (the same as above)
- Add rule that `unsharpMasking.weight` should be greater than 0
- Fix errors when short option was accepting 0 and long was throwing error. For example `{ bl: 0 }` works, `{ blur: 0 }` - doesn't